### PR TITLE
Alignment option

### DIFF
--- a/lib/fairy/fairy.c
+++ b/lib/fairy/fairy.c
@@ -27,6 +27,7 @@
 #include "macros.h"
 
 VerbosityLevel gVerbosity = VERBOSITY_NONE;
+bool gUseRealAlignment = false;
 
 int Fairy_DebugPrintf(const char* file, int line, const char* func,VerbosityLevel level, const char* fmt, ...) {
     if (gVerbosity >= level) {
@@ -258,13 +259,34 @@ void Fairy_InitFile(FairyFileInfo* fileInfo, FILE* file) {
 
                     /* Ignore the leading "." */
                     if (strcmp(&shstrtab[currentSection.sh_name + 1], "text") == 0) {
-                        fileInfo->progBitsSizes[FAIRY_SECTION_TEXT] += ALIGN(currentSection.sh_size, 0x10);
+                        if (gUseRealAlignment) {
+                            // Ensure the next file will start at its correct alignment
+                            fileInfo->progBitsSizes[FAIRY_SECTION_TEXT] = ALIGN(fileInfo->progBitsSizes[FAIRY_SECTION_TEXT], currentSection.sh_addralign);
+                            fileInfo->progBitsSizes[FAIRY_SECTION_TEXT] += ALIGN(currentSection.sh_size, currentSection.sh_addralign);
+                        } else {
+                            fileInfo->progBitsSizes[FAIRY_SECTION_TEXT] += ALIGN(currentSection.sh_size, 0x10);
+                        }
+
                         FAIRY_DEBUG_PRINTF("text section size: 0x%X\n", fileInfo->progBitsSizes[FAIRY_SECTION_TEXT]);
                     } else if (strcmp(&shstrtab[currentSection.sh_name + 1], "data") == 0) {
-                        fileInfo->progBitsSizes[FAIRY_SECTION_DATA] += ALIGN(currentSection.sh_size, 0x10);
+                        if (gUseRealAlignment) {
+                            // Ensure the next file will start at its correct alignment
+                            fileInfo->progBitsSizes[FAIRY_SECTION_DATA] = ALIGN(fileInfo->progBitsSizes[FAIRY_SECTION_DATA], currentSection.sh_addralign);
+                            fileInfo->progBitsSizes[FAIRY_SECTION_DATA] += ALIGN(currentSection.sh_size, currentSection.sh_addralign);
+                        } else {
+                            fileInfo->progBitsSizes[FAIRY_SECTION_DATA] += ALIGN(currentSection.sh_size, 0x10);
+                        }
+
                         FAIRY_DEBUG_PRINTF("data section size: 0x%X\n", fileInfo->progBitsSizes[FAIRY_SECTION_DATA]);
                     } else if (Fairy_StartsWith(&shstrtab[currentSection.sh_name + 1], "rodata")) { /* May be several */
-                        fileInfo->progBitsSizes[FAIRY_SECTION_RODATA] += ALIGN(currentSection.sh_size, 0x10);
+                        if (gUseRealAlignment) {
+                            // Ensure the next file will start at its correct alignment
+                            fileInfo->progBitsSizes[FAIRY_SECTION_RODATA] = ALIGN(fileInfo->progBitsSizes[FAIRY_SECTION_RODATA], currentSection.sh_addralign);
+                            fileInfo->progBitsSizes[FAIRY_SECTION_RODATA] += ALIGN(currentSection.sh_size, currentSection.sh_addralign);
+                        } else {
+                            fileInfo->progBitsSizes[FAIRY_SECTION_RODATA] += ALIGN(currentSection.sh_size, 0x10);
+                        }
+
                         FAIRY_DEBUG_PRINTF("rodata section size: 0x%X\n", fileInfo->progBitsSizes[FAIRY_SECTION_RODATA]);
                     }
                     break;

--- a/lib/fairy/fairy.h
+++ b/lib/fairy/fairy.h
@@ -18,6 +18,7 @@ typedef enum {
 } VerbosityLevel;
 
 extern VerbosityLevel gVerbosity;
+extern bool gUseRealAlignment;
 
 typedef Elf32_Ehdr FairyFileHeader;
 typedef Elf32_Shdr FairySecHeader;

--- a/src/main.c
+++ b/src/main.c
@@ -55,7 +55,7 @@ char* GetOverlayNameFromFilename(const char* src) {
     return ret;
 }
 
-#define OPTSTR "M:n:o:v:hV"
+#define OPTSTR "M:n:o:v:ahV"
 #define USAGE_STRING "Usage: %s [-hV] [-n name] [-o output_file] [-v level] input_files ...\n"
 
 #define HELP_PROLOGUE                                            \
@@ -74,6 +74,8 @@ static const OptInfo optInfo[] = {
     { { "name", required_argument, NULL, 'n' }, "NAME", "Use NAME as the overlay name. Will use the deepest folder name in the input file's path if not specified" },
     { { "output-file", required_argument, NULL, 'o' }, "FILE", "Output to FILE. Will use stdout if none is specified" },
     { { "verbosity", required_argument, NULL, 'v' }, "N", "Verbosity level, one of 0 (None, default), 1 (Info), 2 (Debug)" },
+
+    { { "alignment", no_argument, NULL, 'a' }, NULL, "Use the alignment declared by each section in the elf file instead of padding to 0x10 bytes" },
 
     { { "help", no_argument, NULL, 'h' }, NULL, "Display this message and exit" },
     { { "version", no_argument, NULL, 'V' }, NULL, "Display version information" },
@@ -140,6 +142,10 @@ int main(int argc, char** argv) {
                 if (sscanf(optarg, "%u", &gVerbosity) == 0) {
                     fprintf(stderr, "warning: verbosity argument '%s' should be a nonnegative decimal integer", optarg);
                 }
+                break;
+
+            case 'a':
+                gUseRealAlignment = true;
                 break;
 
             case 'h':

--- a/src/version.inc
+++ b/src/version.inc
@@ -1,5 +1,5 @@
 /* Copyright (C) 2021 Elliptic Ellipsis */
 /* SPDX-License-Identifier: AGPL-3.0-only */
-const char versionNumber[] = "1.1.2";
+const char versionNumber[] = "1.2.0";
 const char credits[] = "Written by Elliptic Ellipsis\n Special Thanks: AngheloAlf";
 const char repo[] = "https://github.com/EllipticEllipsis/fado/";


### PR DESCRIPTION
Adds the `--alignment`/`-a` parameter, which allows to use the alignment of each section in the elf file instead of using a hardcoded 0x10 alignment.