### PR TITLE
Add missing \n to some printfs

### DIFF
--- a/lib/fairy/fairy_print.c
+++ b/lib/fairy/fairy_print.c
@@ -376,7 +376,7 @@ void Fairy_PrintSectionSizes(FairySecHeader* sectionTable, FILE* inputFile, size
     printf(".word 0x%08X # .bss size\n\n", bssSize);
 
     if (!symtabFound) {
-        fprintf(stderr, "Symbol table not found");
+        fprintf(stderr, "Symbol table not found\n");
         return;
     }
     /* Obtain the symbol table */
@@ -384,7 +384,7 @@ void Fairy_PrintSectionSizes(FairySecHeader* sectionTable, FILE* inputFile, size
     Fairy_ReadSymbolTable(&symtab, inputFile, symtabHeader.sh_offset, symtabHeader.sh_size);
 
     if (!strtabFound) {
-        fprintf(stderr, "String table not found");
+        fprintf(stderr, "String table not found\n");
     } else {
         /* Obtain the string table */
         strtab = malloc(strtabHeader.sh_size);

--- a/src/main.c
+++ b/src/main.c
@@ -133,14 +133,15 @@ int main(int argc, char** argv) {
                 outputFileName = optarg;
                 outputFile = fopen(optarg, "wb");
                 if (outputFile == NULL) {
-                    fprintf(stderr, "error: unable to open output file '%s' for writing", optarg);
+                    fprintf(stderr, "error: unable to open output file '%s' for writing\n", optarg);
                     return EXIT_FAILURE;
                 }
                 break;
 
             case 'v':
                 if (sscanf(optarg, "%u", &gVerbosity) == 0) {
-                    fprintf(stderr, "warning: verbosity argument '%s' should be a nonnegative decimal integer", optarg);
+                    fprintf(stderr, "warning: verbosity argument '%s' should be a nonnegative decimal integer\n",
+                            optarg);
                 }
                 break;
 
@@ -182,7 +183,7 @@ int main(int argc, char** argv) {
             FAIRY_INFO_PRINTF("Using input file %s\n", argv[optind + i]);
             inputFiles[i] = fopen(argv[optind + i], "rb");
             if (inputFiles[i] == NULL) {
-                fprintf(stderr, "error: unable to open input file '%s' for reading", argv[optind + i]);
+                fprintf(stderr, "error: unable to open input file '%s' for reading\n", argv[optind + i]);
                 return EXIT_FAILURE;
             }
         }
@@ -214,14 +215,14 @@ int main(int argc, char** argv) {
         FILE* dependencyFile = fopen(dependencyFileName, "w");
 
         if (dependencyFile == NULL) {
-            fprintf(stderr, "error: unable to open dependency file '%s' for writing", dependencyFileName);
+            fprintf(stderr, "error: unable to open dependency file '%s' for writing\n", dependencyFileName);
             return EXIT_FAILURE;
         }
 
         strcpy(objectFile, outputFileName);
         extensionStart = strrchr(objectFile, '.');
         if (extensionStart == objectFile + fileNameLength) {
-            fprintf(stderr, "error: file name should not end in a '.'");
+            fprintf(stderr, "error: file name should not end in a '.'\n");
             return EXIT_FAILURE;
         }
         strcpy(extensionStart, ".o");


### PR DESCRIPTION
It took me some time to realize the error message
```
error: unable to open input file 'build/src/overlays/gamestates/ovl_file_choose/file_select.o' for readingmake: *** [Makefile:343: build/src/overlays/gamestates/ovl_file_choose/ovl_file_choose_reloc.o] Error 1
```
Was really
```
error: unable to open input file 'build/src/overlays/gamestates/ovl_file_choose/file_select.o' for reading
make: *** [Makefile:343: build/src/overlays/gamestates/ovl_file_choose/ovl_file_choose_reloc.o] Error 1
```
without the line break in between

I fixed that and found other printfs that I assume also are missing a line break at the end