### PR TITLE
Add alloc flag to the section type

### DIFF
--- a/lib/fairy/fairy_print.c
+++ b/lib/fairy/fairy_print.c
@@ -368,7 +368,7 @@ void Fairy_PrintSectionSizes(FairySecHeader* sectionTable, FILE* inputFile, size
         }
     }
     /* Can use symbols here too */
-    puts(".section .ovl");
+    puts(".section .ovl, \"a\"");
     printf("# OverlayInfo\n");
     printf(".word 0x%08X # .text size\n", textSize);
     printf(".word 0x%08X # .data size\n", dataSize);

--- a/src/fado.c
+++ b/src/fado.c
@@ -251,7 +251,7 @@ void Fado_Relocs(FILE* outputFile, int inputFilesCount, FILE** inputFiles, const
 
     {
         /* Write header */
-        fprintf(outputFile, ".section .ovl\n");
+        fprintf(outputFile, ".section .ovl, \"a\"\n");
         fprintf(outputFile, "# %sOverlayInfo\n", ovlName);
         fprintf(outputFile, ".word _%sSegmentTextSize\n", ovlName);
         fprintf(outputFile, ".word _%sSegmentDataSize\n", ovlName);

--- a/src/version.inc
+++ b/src/version.inc
@@ -1,5 +1,5 @@
 /* Copyright (C) 2021 Elliptic Ellipsis */
 /* SPDX-License-Identifier: AGPL-3.0-only */
-const char versionNumber[] = "1.3.1";
+const char versionNumber[] = "1.3.2";
 const char credits[] = "Written by Elliptic Ellipsis\nwith additions from AngheloAlf and Tharo";
 const char repo[] = "https://github.com/EllipticEllipsis/fado/";


### PR DESCRIPTION
Currently relocs generated by fado don't have any kind of flag on the section directive. This is bad because, according to the gas documentation:

> If no flags are specified, the default flags depend upon the section name. If the section name is not recognized, the default will be for the section to have none of the above flags: it will not be allocated in memory, nor writable, nor executable. The section will contain data.

https://sourceware.org/binutils/docs/as/Section.html#ELF-Version

This means trying to link only the `.ovl` section for the generated reloc will produce only zeroes to be linked into the main executable instead of the actual data.
Linking the reloc works fine in OoT/MM because their linker script lists all the sections from the reloc (including the empty `.text`, `.data`, etc) which do have the "alloc" flag set, producing this the data of this section to be linked properly. This doesn't sound like a behavior that should be relied on and may change in the future (I couldn't find documentation about this). Wanting to only link the `.ovl` section of the generated reloc should also be a proper way to use them.

