### PR TITLE
Fix dropped .text relocations when referencing .bss symbols in other files

### DIFF
--- a/src/fado.c
+++ b/src/fado.c
@@ -17,16 +17,6 @@
 
 /* String-finding-related functions */
 
-bool Fado_CheckInProgBitsSections(Elf32_Section section, vc_vector* progBitsSections) {
-    Elf32_Section* i;
-    VC_FOREACH(i, progBitsSections) {
-        if (*i == section) {
-            return true;
-        }
-    }
-    return false;
-}
-
 /**
  * For each input file, construct a vector of pointers to the starts of the strings defined in that file.
  */
@@ -41,8 +31,7 @@ void Fado_ConstructStringVectors(vc_vector** stringVectors, FairyFileInfo* fileI
 
         /* Build a vector of pointers to defined symbols' names */
         for (currentSym = 0; currentSym < fileInfo[currentFile].symtabInfo.sectionEntryCount; currentSym++) {
-            if ((symtab[currentSym].st_shndx != STN_UNDEF) &&
-                Fado_CheckInProgBitsSections(symtab[currentSym].st_shndx, fileInfo[currentFile].progBitsSections)) {
+            if (symtab[currentSym].st_shndx != STN_UNDEF) {
                 /* Have to pass a double pointer so it copies the pointer instead of the start of the string */
                 char* stringPtr = &fileInfo[currentFile].strtab[symtab[currentSym].st_name];
                 assert(vc_vector_push_back(stringVectors[currentFile], &stringPtr));


### PR DESCRIPTION
Fixes this kind of situation:
```c
// File 1

s32 g_foobar; // .bss

void foo(void) {
    g_foobar = 1;
    bar();
}

// File 2

void bar(void) {
    baz(g_foobar); // this would be unrelocated due to missing relocations so baz would receive the wrong value
}
```

This still matches and as far as I can tell there should be no need to limit to progbits sections only?